### PR TITLE
Added: User output when server is ready so that Pterodactly can detec…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Local configuration files
 config.json
 .env
+
+# Local Temporary files
+/tmp

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,7 @@ func setupEnv() {
 
 	_, err := os.Stat(envFile)
 	if err != nil {
-		utils.HandleError(err, true)
+		log.Warn("No .env file found, will not attempt to configure environment...")
 	} else {
 		err := godotenv.Load(envFile)
 		utils.HandleError(err, true)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,6 +97,8 @@ func serve(configFilePath, tmpDirPath string) {
 
 	startScheduler(configFile, tmpDirPath)
 
+	log.Info("Server started")
+
 	for {
 		time.Sleep(time.Second)
 	}

--- a/metadata.json
+++ b/metadata.json
@@ -1,4 +1,4 @@
 {
   "name": "pterodactyl-backup-manager",
-  "version": "0.1.3"
+  "version": "0.1.4"
 }


### PR DESCRIPTION
…t when the server is up and running.

Fixed: Startup fatal error if the `.env` file doesn't exist, the applicaiton will now ignore and continue running if its missing.